### PR TITLE
로그인/로그아웃 시 헤더 버튼 변경 및 페이지 리로드 & 푸터 css 주석제거

### DIFF
--- a/src/components/footer/Footer.js
+++ b/src/components/footer/Footer.js
@@ -69,7 +69,6 @@ function Footer() {
           </FooterBodyRight>
         </FooterBody>
       </FooterInner>
-      {/* <TopButton>Top</TopButton> */}
     </FooterContainer>
   );
 }
@@ -81,7 +80,6 @@ const FooterContainer = styled.div`
   height: 20rem;
   color: rgb(170, 170, 170);
   background-color: rgb(55, 55, 55);
-  // font-family: 'Spoqa Han Sans Neo', 'sans-serif';
 `;
 
 const FooterInner = styled.div`
@@ -147,12 +145,3 @@ const IconWrap = styled.div`
   font-size: 1.5rem;
   color: white;
 `;
-// const TopButton = styled.button`
-//   position: fixed;
-//   width: 3rem;
-//   height: 3rem;
-//   right: 1rem;
-//   bottom: 1rem;
-//   border: none;
-//   // border-radius: 50%;
-// `;

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -1,9 +1,14 @@
 import React from 'react';
 import styled from 'styled-components';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 function Header() {
   const navigate = useNavigate();
-
+  const token = localStorage.getItem('access_token');
+  const Logout = () => {
+    localStorage.removeItem('access_token');
+    window.location.reload();
+    console.log('로그아웃!');
+  };
   return (
     <Wrapper>
       <LogoWrapper onClick={() => navigate('/')}>
@@ -13,12 +18,22 @@ function Header() {
         <Link onClick={() => navigate('/search')}>지도</Link>
         <Link onClick={() => navigate('/favorites/recent-room')}>관심목록</Link>
         <Link onClick={() => navigate('/manage/form')}>방내놓기</Link>
-        <Button onClick={() => navigate('/login')}>
-          <Login>로그인</Login>
-        </Button>
-        <Button onClick={() => navigate('/signup')}>
-          <SignUp>회원가입</SignUp>
-        </Button>
+        {token ? (
+          <>
+            <Button onClick={() => Logout()}>
+              <Login>로그아웃</Login>
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button onClick={() => navigate('/login')}>
+              <Login>로그인</Login>
+            </Button>
+            <Button onClick={() => navigate('/signup')}>
+              <SignUp>회원가입</SignUp>
+            </Button>
+          </>
+        )}
       </MenuWrapper>
     </Wrapper>
   );

--- a/src/components/header/MainHeader.js
+++ b/src/components/header/MainHeader.js
@@ -4,7 +4,12 @@ import { useNavigate } from 'react-router-dom';
 
 function MainHeader() {
   const navigate = useNavigate();
-
+  const token = localStorage.getItem('access_token');
+  const Logout = () => {
+    localStorage.removeItem('access_token');
+    window.location.reload();
+    console.log('로그아웃!');
+  };
   return (
     <Wrapper>
       <Header>
@@ -17,12 +22,22 @@ function MainHeader() {
             관심목록
           </Link>
           <Link onClick={() => navigate('/manage/form')}>방내놓기</Link>
-          <Button onClick={() => navigate('/login')}>
-            <Login>로그인</Login>
-          </Button>
-          <Button onClick={() => navigate('/signup')}>
-            <SignUp>회원가입</SignUp>
-          </Button>
+          {token ? (
+            <>
+              <Button onClick={() => Logout()}>
+                <Login>로그아웃</Login>
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button onClick={() => navigate('/login')}>
+                <Login>로그인</Login>
+              </Button>
+              <Button onClick={() => navigate('/signup')}>
+                <SignUp>회원가입</SignUp>
+              </Button>
+            </>
+          )}
         </MenuWrapper>
       </Header>
       <Search>


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 로그인시 헤더 변경, 로그아웃시 헤더 변경 

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. 로그인 시 토큰 발급받고 헤더의 로그인/회원가입 버튼이 로그아웃 버튼으로 변경
2. 로그아웃시 토큰 삭제하고 헤더의 로그아웃 버튼이 로그인/회원가입 버튼으로 변경

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

- <br />

## :: 기타 질문 및 특이 사항

- 기타 질문 및 특이 사항 올려주세요
